### PR TITLE
feat: reliable knowledge write-back, detached extraction, and markdow…

### DIFF
--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -7,6 +7,7 @@
         backend: local
         databasePath: !!js dshHomePath('knowledge/knowledge.sqlite')
         connectionPath: !!js dshHomePath('knowledge/connection.json')
+        exportsDir: !!js dshHomePath('knowledge/exports')
         exposeApi: false
         exposeWeb: true
         extractionEnabled: true

--- a/docs/writeback-fix-plan.md
+++ b/docs/writeback-fix-plan.md
@@ -1,0 +1,94 @@
+# dsh-knowledge 回写可靠性修复 + 导入/导出 — Coding Plan（已批准）
+
+状态：**已批准，实施中**（2026-08-31 用户逐条 review 定稿并放行）。
+实现仓库：`D:\Ollama\projects\github\dsh-knowledge`（工作区源码 2.1.1；实际安装于 `~/.dsh/profiles/web` 的是 1.1.5 独立副本，信号链已核实一致）。
+同步副本：Mnemon 项目文档《dsh-knowledge 回写可靠性修复与导入导出 — 设计与实施 Plan》。
+
+## 1. 根因（已代码 + DB 取证）
+
+1. `extractionTimeoutMs` 默认 90s（src/config.ts:44）；长答案提取模型调用必超时。pi-ai 在 signal abort 时统一抛 `Request was aborted` 并丢弃 `signal.reason` → 超时/回合中断在 `extraction_jobs.last_error` 中不可分辨（DB 中 3 条 failed 全为此值、attempts=1）。
+2. 无自动重试：`claimExtraction` 的 `attempts<3` 只是领取上限（local-provider.ts:1383），不存在任何调度器。
+3. 手动重试（POST /knowledge-control/v1/writeback-status）用 fresh signal + resetExtraction，但同样预算跑同样长内容 → 确定性复败。
+4. 回合中断：dsh-agent-loop `cancel()` → `phase.abort.abort()`（lib/index.js:410,565）→ 插件 parentSignal；`runWriteback` 的 `if (signal.aborted) throw error`（index.ts:352）在落终态前抛出 → `writebackStatuses` 永久 running、UI 无重试按钮、该轮永无再次回写。
+
+## 2. 已确认决策
+
+- **detached 为默认**：新增 `extractionMode: 'detached' | 'inline'`，默认 detached；inline 保留旧行为。
+- **extractionTimeoutMs 默认 300_000**；保留配置 `0` = 禁用单次超时的语义（逃生门，非默认）。
+- **自动重试链**：首次失败 → 退避 20s → 重试1（预算 300s）→ 失败 → 退避 60s → 重试2（预算 300s）→ 失败 → 退避 60s → **最后一搏（超时 30 分钟，常量 `FINAL_ATTEMPT_TIMEOUT_MS`）** → 仍失败 → `failed+retryable`。兜底前 `resetExtraction`（绕过 DB attempts<3）；调度器用内存 `autoRetryCount` 计数。
+- **重试按钮仅在整条链全部失败后出现**；链运行中保持 `running` + 阶段文案（"20 秒后自动重试（1/2）"等）。手动重试 = reset + 重开整条链，不是无限自动循环。
+- **最后一搏失败后自动导出待抽取内容为 MD，落点 B：`<DSH home>/knowledge/exports/`**。
+- **「导入文件」按钮只支持 `.md/.markdown`**（不做 html/pdf/word 转换、不做转换 bundle、不做从笔记导入）。
+
+## 3. W1 修复（src/index.ts、src/extraction.ts、src/config.ts、src/local-provider.ts）
+
+- extraction.ts `callExtractionModel`：catch 中区分 abort 来源——`controller.signal.aborted && !parentSignal.aborted` → 抛 `知识提取超时（预算 Nms）`；parentSignal.aborted → 抛 `回合已中断`；最后一搏用 `options.timeoutMs` 覆盖（`run()` 增加 `options?: { timeoutMs?: number }` 逐层穿透 `extractWithLlm → callStructuredModel → callExtractionModel`）。
+- index.ts `runWriteback`：任何失败（含 signal.aborted）都先落 `failed+retryable` 终态再决定上抛；初跑 summary "正在重试" 改 "正在回写"。
+- index.ts：自动重试调度器（pending-timer Map 防重；退避 20s/60s；autoRetryCount 计数；重跑前查 `provider.extractionJob(key)`；dispose 清空全部 timer）。
+- local-provider.ts `claimExtraction` 增加可选 `leaseMs`（默认 15min 不变）；最后一搏 claim 时传 35min，消除 30min 尝试期间 "running 且超 15min" 的 stale 竞态（remote provider 忽略该参数，残余风险仅限同库双实例，可接受）。
+
+## 4. W2 后台化（detached）
+
+- extraction.ts `run()`：工作信号 = `AbortSignal.any([timeoutController, shutdown])`，不再合并 parentSignal。
+- index.ts：detached 模式下 turn-stopping handler 为 `void runWriteback(...)`（内部 catch 记日志+落终态），不 await → 不阻塞 turn/end，追问不再中断回写。
+- coordinator 维护 in-flight 集合；`close()` 先 `shutdown.abort` 再 `await Promise.allSettled(inflight)`（宽限 30s）。
+- 幂等不变：sourceKey 唯一 claim + 租约；UI 零改动（turnTail 轮询 GET writeback-status）。
+- 边界：进程被直接杀 → 任务丢、job 停 running、租约过期后可重新领取；跨重启自动重试不做（需持久化 turn 快照，收益低）。
+
+## 5. W3 失败导出（落点 B 已确认）
+
+- **默认目录：`<DSH home>/knowledge/exports/`**（本机即 `C:\Users\reame\.dsh\knowledge\exports\`，与 knowledge.sqlite/notes/documents 同级）。
+- 实现要点：cordis.patch.yml 增加配置项 `exportsDir: !!js dshHomePath('knowledge/exports')` 作为默认值——**不用 `dirname(databasePath)` 推导**，因为 remote 后端没有本地 databasePath；导出是本机救援产物，永远写客户端自己的 DSH home，**绝不通过 provider 写库**（local 不污染库目录结构，remote 不写中央服务端）。config 可显式覆盖 exportsDir；resolveConfig 缺省回退：exportsDir 未配置且 backend=local 时用 `dirname(databasePath)/exports`，remote 且未配置则跳过导出并在状态里注明。
+- 触发：自动链（含 30min 最后一搏）全部失败后、落 failed 终态前执行一次（source.agent 快照仍在内存，可重建 turn 内容）。
+- 内容：H1 = 用户提问首行截断 ≤60 字；blockquote `> 来源：DSH 会话 <id 前 8> 第 <turn> 轮（<date>）· dsh-knowledge 导出`；`## 用户提问` 全文；`## 助手回答` 全文；顶部 HTML 注释 provenance（不用 YAML front matter，避免与 parseKnowledgeMarkdown 校验冲突）。
+- UI：失败状态显示「已导出：回写失败-xxx.md」+「下载 Markdown」按钮——客户端 fetch 控制端点（带 `x-dsh-knowledge-client: conversation-web` 头）取 blob 后 `a.download` 触发保存到浏览器下载目录（裸 `<a href>` 不携带自定义头会 401，必须 fetch+blob）。
+- 控制端点：`GET /knowledge-control/v1/writeback-export?sessionId&turn`，`assertKnowledgeBrowserRequest(req,'conversation-web')`，读 exportsDir 下对应文件，响应 `Content-Disposition: attachment; filename*=UTF-8''...`（RFC5987 中文文件名）。
+- 文件名：`回写失败-<turn>-<MMdd-HHmmss>.md`；同 turn 同名已存在则复用；v1 不做自动清理。
+- 状态：`writebackStatuses` state 增加 `export?: { fileName }`；GET /writeback-status 返回。导出失败不阻塞 failed 终态。
+
+## 6. W4 导入文件（简化版：仅 md）
+
+- 入口：`renderDocumentWorkspace` 工具栏「新建文档」旁加「导入文件」（库详情与会话工作区共用组件，一处改动两处生效）。
+- 仅接受 `.md/.markdown`（file input accept 限定；其他格式提示不支持）；前端 `FileReader` 读文本。
+- 标题：文件名去扩展名或首个 H1（`src/import-utils.ts` 纯函数，编译进 lib，浏览器与 node 测试共用）。
+- >50k 处理：body 上限 50,000 字符（normalizeDraft 硬校验），超限对话框默认「按 H2 拆分为多篇（`文件名 (1/N)`）」，可选「截断」或取消。
+- 创建前对话框：目标知识库（默认当前上下文）、类型（默认 fact）、标签、scope（project=当前 cwd / global）；提交复用 `POST /entries`（write），零新路由、零新依赖、零新 bundle。
+
+## 7. 测试（test/plugin-runtime.test.mjs 扩展 + 新增）
+
+- T1 detached：回合信号 abort（模拟追问）后提取仍完成并产出候选。
+- T2 自动重试：fake llm 首次抛 abort → 退避后自动重跑成功 → attempts=2、completed、summary 注明自动重试。
+- T3 中断终态化：abort 后 writebackStatuses 出现 failed+retryable（不再卡 running）。
+- T4 天花板：2 次退避 + 30min 兜底全部失败后才 failed+retryable；链中保持 running。
+- T5 语义化：超时 last_error 含「超时」；30min 兜底超时文案区分。
+- T6 inline 回归：extractionMode='inline' 旧行为不变。
+- T7 兜底超时预算：最后一搏使用 30min 预算与 35min lease（参数穿透验证）。
+- T8 失败导出：兜底失败后 exportsDir 写入 md、state.export 存在、同名复用、exportsDir 未配置（remote）时状态注明跳过。
+- T9 import-utils：标题推导、H2 拆分边界（50k、空节）。
+- 回归命令：`npm test`（build + node --test test/*.test.mjs）。
+
+## 8. 发布
+
+1. 版本 bump（2.2.0）→ `npm test` → `npm pack`。
+2. `dsh plugin --profile web add .\lemoncat7-dsh-knowledge-<ver>.tgz` 覆盖安装 1.1.5。
+3. 重启 profile（重启会杀进行中对话；用延迟分离脚本或用户手动跑 `C:\Users\reame\.dsh\restart-dsh-web.cmd`）。
+4. 实测：长回答 + 立即追问 → 回写最终落定；制造连续失败 → 观察 20s/60s/30min 链、exports/ 导出与下载按钮；导入大 md 验证拆分。
+
+## 9. 决策记录
+
+全部确认于 2026-08-31：detached 默认 ✅、300s 默认 ✅、重试时序（20s/60s×2 + 30min 兜底）✅、按钮仅链全败后出现 ✅、导出落点 B ✅、导入仅 md ✅。
+
+## 10. 实施记录与偏差（2026-08-31 完成，npm test 72/72 全绿）
+
+实现与计划完全对应（W1-W4、T1-T9、2.2.0、npm pack），以下为实施时的具体偏差与补充，均为等价或增强：
+
+1. **重试时序全部可配置**（计划中的常量 → config）：新增 `extractionRetryDelaysMs`（默认 `[20_000, 60_000]`，最多 2 项）、`extractionFinalRetryDelayMs`（默认 60_000）、`extractionFinalTimeoutMs`（默认 1_800_000）。测试用 10ms 级时序驱动全链，用户亦可自行调节。extractionTimeoutMs schema 上限从 300_000 保持不变，0=禁用语义保留。
+2. **lease = finalTimeout + 300_000**（而非固定 35min）：`extractionFinalTimeoutMs` 可配置后，lease 随之动态计算，关系不变（lease > 尝试超时 5min 余量）。
+3. **import-utils 位置：`web/import-utils.js`**（而非 `src/import-utils.ts`）：app.js 是 `<script type="module">`，浏览器侧直接 `import(...?v=ASSET_VERSION)` 动态加载，零构建零依赖；node 测试直接 import 同一文件。`IMPORT_ACCEPT='.md,.markdown'`、`IMPORT_MAX_BODY_CHARS=50_000`、`titleFromMarkdown`、`splitMarkdownByH2`（H2 边界优先、无标题/超长节硬切）。
+4. **POST 手动重试改为 fire-and-forget**：立即返回 `running`（"正在重试（手动）"），整条链后台执行；client.tsx 增加 5s 轮询（仅 running 期间），完成/失败后自动刷新。
+5. **T7 合并进 T4**（lease 穿透由 T4 的 4 次调用断言覆盖）；T8 合并进 T4 的导出+下载+同名复用断言。
+6. **detached 语义精确化**：coordinator.run 的 detached 工作信号 = `AbortSignal.any([timeoutController, shutdown])`（只排除 parentSignal）；runWriteback 收到的 parentSignal 仅用于判定"回合已中断"文案，不取消提取。detached 下 turn-stopping 对提取尚未开始的轮次照常启动（fresh AbortController），关闭时 `coordinator.close()` = shutdown.abort + allSettled(inflight) + 30s 宽限，进程退出不被卡住。
+7. **测试基建坑**：node:test after 钩子按注册顺序 **FIFO** 执行（node 24 实测），旧测试"disposers+rm 钩子先注册、observer.close 后注册"会导致 rm 在 observer 未关时跑 → Windows WAL sqlite EBUSY。已统一改为钩子内先 `await observer.close()` 再 dispose 再带 EBUSY 重试的 rm；audit 测试的 `reopened` 第二连接改为测试末尾显式 close。Windows 下 POSIX mode 位断言（0o600）恒为 0o666，connection/service-settings 两测试加 `process.platform !== 'win32'` 守卫。
+8. **cordis-integration 期望路由表**补上新增的 `/knowledge-control/v1/writeback-export`。
+9. 发布产物：`lemoncat7-dsh-knowledge-2.2.0.tgz`（npm pack 通过，含 prepare 完整构建）。
+10. **热修 2.2.1**：用户实测发现「导入组件加载失败」——`src/web.ts` 的 `STATIC_ASSETS` 是启动时读入内存的固定清单，动态 import 的 `web/import-utils.js` 未登记 → 运行时 404。已补登记并加回归断言（cordis 集成测试的 FakeWebServer 同步补齐 prefix 路由分发，实测 fetch `/knowledge/import-utils.js` 返回 200 + `text/javascript`）。教训：**往 web/ 加任何新静态资源必须同步登记 STATIC_ASSETS**。2.2.1 已重新 pack（shasum 19b77914…）并安装进 profile。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lemoncat7/dsh-knowledge",
-  "version": "2.1.1",
+  "version": "2.2.2",
   "description": "Local and remote knowledge bases for DeepSeek Harness, with scoped recall, controlled write-back, and a Web management console",
   "keywords": [
     "deepseek-harness",

--- a/src/client.tsx
+++ b/src/client.tsx
@@ -73,23 +73,41 @@ export function apply(ctx: ClientContext): void {
 }
 
 function KnowledgeWritebackStatus({ sessionId, turn }: { sessionId: string; turn: number }) {
-  type Status = { status: 'running' | 'completed' | 'failed'; summary: string; error?: string; retryable: boolean }
+  type Status = {
+    status: 'running' | 'completed' | 'failed'
+    summary: string
+    error?: string
+    retryable: boolean
+    export?: { fileName: string }
+  }
   const [state, setState] = useState<Status>()
-  const [retrying, setRetrying] = useState(false)
+  const [busy, setBusy] = useState<'' | 'retry' | 'download'>('')
+  const basePath = `/knowledge-control/v1/writeback-status?sessionId=${encodeURIComponent(sessionId)}&turn=${turn}`
+  const load = useCallback(async (): Promise<void> => {
+    const response = await fetch(basePath, {
+      headers: { accept: 'application/json', 'x-dsh-knowledge-client': 'conversation-web' },
+    })
+    if (!response.ok) return
+    const value = await response.json() as Status
+    if (value?.summary) setState(value)
+  }, [basePath])
   useEffect(() => {
     const controller = new AbortController()
-    void fetch(`/knowledge-control/v1/writeback-status?sessionId=${encodeURIComponent(sessionId)}&turn=${turn}`, {
-      headers: { accept: 'application/json', 'x-dsh-knowledge-client': 'conversation-web' }, signal: controller.signal,
-    }).then(async response => response.ok ? response.json() as Promise<Status> : undefined)
-      .then(value => { if (value?.summary) setState(value) })
-      .catch(() => {})
+    void load().catch(() => {})
     return () => { controller.abort() }
-  }, [sessionId, turn])
+  }, [load])
+  // The automatic retry chain keeps the status 'running' for minutes; poll so
+  // the stage text and the retry button appear without a page reload.
+  useEffect(() => {
+    if (state?.status !== 'running') return
+    const timer = window.setInterval(() => { void load().catch(() => {}) }, 5000)
+    return () => { window.clearInterval(timer) }
+  }, [state?.status, load])
   if (state === undefined) return null
   const retry = async (): Promise<void> => {
-    setRetrying(true)
+    setBusy('retry')
     try {
-      const response = await fetch(`/knowledge-control/v1/writeback-status?sessionId=${encodeURIComponent(sessionId)}&turn=${turn}`, {
+      const response = await fetch(basePath, {
         method: 'POST', headers: { accept: 'application/json', 'x-dsh-knowledge-client': 'conversation-web' },
       })
       if (!response.ok) throw new Error(`retry failed with HTTP ${response.status}`)
@@ -98,11 +116,37 @@ function KnowledgeWritebackStatus({ sessionId, turn }: { sessionId: string; turn
       setState(previous => previous === undefined ? previous : {
         ...previous, error: error instanceof Error ? error.message : String(error), retryable: true,
       })
-    } finally { setRetrying(false) }
+    } finally { setBusy('') }
+  }
+  const download = async (): Promise<void> => {
+    if (state?.export === undefined) return
+    setBusy('download')
+    try {
+      const response = await fetch(`/knowledge-control/v1/writeback-export?sessionId=${encodeURIComponent(sessionId)}&turn=${turn}`, {
+        headers: { accept: 'text/markdown', 'x-dsh-knowledge-client': 'conversation-web' },
+      })
+      if (!response.ok) throw new Error(`导出下载失败（HTTP ${response.status}）`)
+      const blob = await response.blob()
+      const url = URL.createObjectURL(blob)
+      const anchor = document.createElement('a')
+      anchor.href = url
+      anchor.download = state.export.fileName
+      document.body.append(anchor)
+      anchor.click()
+      anchor.remove()
+      window.setTimeout(() => URL.revokeObjectURL(url), 1000)
+    } catch (error) {
+      setState(previous => previous === undefined ? previous : {
+        ...previous, error: error instanceof Error ? error.message : String(error),
+      })
+    } finally { setBusy('') }
   }
   return <div className="dsh-knowledge-writeback-status">
     <span>上下文注入</span><strong>dsh-knowledge</strong><span title={state.error}>{state.summary}</span>
-    {state.status === 'failed' && state.retryable && <button type="button" disabled={retrying} onClick={() => { void retry() }}>{retrying ? '重试中…' : '重试'}</button>}
+    {state.status === 'failed' && state.export !== undefined
+      && <button type="button" disabled={busy !== ''} onClick={() => { void download() }}>{busy === 'download' ? '下载中…' : '下载 Markdown'}</button>}
+    {state.status === 'failed' && state.retryable
+      && <button type="button" disabled={busy !== ''} onClick={() => { void retry() }}>{busy === 'retry' ? '重试中…' : '重试'}</button>}
   </div>
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
 import Schema from '@deepseek-ai/schemastery'
+import { dirname, join } from 'node:path'
 import { normalizeRemoteKnowledgeUrl } from './remote-url.js'
 
 export interface Config {
@@ -13,11 +14,16 @@ export interface Config {
   apiPrefix: string
   exposeWeb: boolean
   webPath: string
+  exportsDir?: string
   extractionEnabled: boolean
+  extractionMode: 'detached' | 'inline'
   extractionProvider?: string
   extractionModel?: string
   extractionMaxTokens: number
   extractionTimeoutMs: number
+  extractionRetryDelaysMs: number[]
+  extractionFinalRetryDelayMs: number
+  extractionFinalTimeoutMs: number
   extractionMaxInputChars: number
   defaultScope: 'project' | 'global'
   autoRecallLimit: number
@@ -37,11 +43,16 @@ export const Config: Schema<Config> = Schema.object({
   apiPrefix: Schema.string().default('/knowledge-api/v1'),
   exposeWeb: Schema.boolean().default(true),
   webPath: Schema.string().default('/knowledge'),
+  exportsDir: Schema.string(),
   extractionEnabled: Schema.boolean().default(true),
+  extractionMode: Schema.union(['detached', 'inline']).default('detached'),
   extractionProvider: Schema.string(),
   extractionModel: Schema.string(),
   extractionMaxTokens: Schema.number().min(128).max(8192).default(4096),
-  extractionTimeoutMs: Schema.number().min(1000).max(300_000).default(90_000),
+  extractionTimeoutMs: Schema.number().min(0).max(300_000).default(300_000),
+  extractionRetryDelaysMs: Schema.array(Schema.number().min(0)).default([20_000, 60_000]),
+  extractionFinalRetryDelayMs: Schema.number().min(0).max(600_000).default(60_000),
+  extractionFinalTimeoutMs: Schema.number().min(1000).max(3_600_000).default(1_800_000),
   extractionMaxInputChars: Schema.number().min(1000).max(200_000).default(30_000),
   defaultScope: Schema.union(['project', 'global']).default('project'),
   autoRecallLimit: Schema.number().min(0).max(10).default(3),
@@ -54,8 +65,13 @@ export interface ResolvedConfig extends Config {
   apiPrefix: string
   exposeWeb: boolean
   webPath: string
+  exportsDir?: string
+  extractionMode: 'detached' | 'inline'
   extractionMaxTokens: number
   extractionTimeoutMs: number
+  extractionRetryDelaysMs: number[]
+  extractionFinalRetryDelayMs: number
+  extractionFinalTimeoutMs: number
   extractionMaxInputChars: number
   defaultScope: 'project' | 'global'
   autoRecallLimit: number
@@ -65,6 +81,7 @@ export interface ResolvedConfig extends Config {
 
 export function resolveConfig(config: Config): ResolvedConfig {
   const connectionPath = config.connectionPath ?? deriveConnectionPath(config.databasePath)
+  const exportsDir = resolveExportsDir(config.exportsDir, config.backend, config.databasePath)
   const resolved: ResolvedConfig = {
     ...config,
     remoteTimeoutMs: config.remoteTimeoutMs ?? 10_000,
@@ -72,8 +89,13 @@ export function resolveConfig(config: Config): ResolvedConfig {
     apiPrefix: normalizePrefix(config.apiPrefix ?? '/knowledge-api/v1'),
     exposeWeb: config.exposeWeb ?? true,
     webPath: normalizePrefix(config.webPath ?? '/knowledge'),
+    ...exportsDir === undefined ? {} : { exportsDir },
+    extractionMode: config.extractionMode === 'inline' ? 'inline' : 'detached',
     extractionMaxTokens: config.extractionMaxTokens ?? 4096,
-    extractionTimeoutMs: config.extractionTimeoutMs ?? 90_000,
+    extractionTimeoutMs: config.extractionTimeoutMs ?? 300_000,
+    extractionRetryDelaysMs: normalizeRetryDelays(config.extractionRetryDelaysMs),
+    extractionFinalRetryDelayMs: config.extractionFinalRetryDelayMs ?? 60_000,
+    extractionFinalTimeoutMs: config.extractionFinalTimeoutMs ?? 1_800_000,
     extractionMaxInputChars: config.extractionMaxInputChars ?? 30_000,
     defaultScope: config.defaultScope ?? 'project',
     autoRecallLimit: config.autoRecallLimit ?? 3,
@@ -107,6 +129,25 @@ export function resolveConfig(config: Config): ResolvedConfig {
 
 function deriveConnectionPath(databasePath: string | undefined): string | undefined {
   return databasePath === undefined || databasePath.trim().length === 0 ? undefined : `${databasePath}.connection.json`
+}
+
+function resolveExportsDir(value: string | undefined, backend: Config['backend'], databasePath: string | undefined): string | undefined {
+  const trimmed = value?.trim()
+  if (trimmed !== undefined && trimmed.length > 0) return trimmed
+  if (backend === 'local' && databasePath !== undefined && databasePath.trim().length > 0) {
+    return join(dirname(databasePath), 'exports')
+  }
+  return undefined
+}
+
+function normalizeRetryDelays(value: unknown): number[] {
+  const delays = (Array.isArray(value) ? value : [])
+    .map(item => typeof item === 'number' && Number.isFinite(item) && item >= 0 ? item : -1)
+    .filter(delay => delay >= 0)
+    .slice(0, 2)
+  const fallbacks = [20_000, 60_000]
+  while (delays.length < 2) delays.push(fallbacks[delays.length] ?? 60_000)
+  return delays
 }
 
 function normalizePrefix(value: string): string {

--- a/src/extraction.ts
+++ b/src/extraction.ts
@@ -16,9 +16,18 @@ interface TurnSnapshot {
   route?: { provider: string; model: string }
 }
 
+/** Per-attempt overrides threaded from the writeback retry chain. */
+export interface ExtractionRunOptions {
+  timeoutMs?: number
+  leaseMs?: number
+}
+
+const EXTRACTION_CLOSE_GRACE_MS = 30_000
+
 export class ExtractionCoordinator {
   private closing = false
   private readonly shutdown = new AbortController()
+  private readonly inflight = new Set<Promise<unknown>>()
 
   constructor(
     private readonly ctx: RuntimeContextLike,
@@ -27,30 +36,60 @@ export class ExtractionCoordinator {
     private readonly clientRoute: () => { provider: string; model: string } | undefined = () => undefined,
   ) {}
 
-  async run(session: SessionLike, turn: number, parentSignal: AbortSignal): Promise<ExtractionResult> {
+  async run(
+    session: SessionLike,
+    turn: number,
+    parentSignal: AbortSignal,
+    options: ExtractionRunOptions = {},
+  ): Promise<ExtractionResult> {
     if (this.closing) return emptyResult('skipped')
     const snapshot = snapshotTurn(session, turn, this.config.extractionMaxInputChars)
     if (snapshot === undefined) return emptyResult('skipped')
     const mounts = (await this.provider.resolveMounts(session.id, snapshot.projectId, parentSignal))
       .filter(mount => mount.writeMode !== 'none')
     if (mounts.length === 0) return emptyResult('unmounted')
-    return this.process(snapshot, mounts, AbortSignal.any([parentSignal, this.shutdown.signal]))
+    // Detached mode decouples extraction from the turn lifecycle: the work
+    // signal only carries the timeout budget and the plugin shutdown signal,
+    // so a user follow-up can no longer abort the running writeback.
+    const detached = this.config.extractionMode !== 'inline'
+    const workSignal = detached
+      ? AbortSignal.any([this.shutdown.signal])
+      : AbortSignal.any([parentSignal, this.shutdown.signal])
+    const attempt: Promise<ExtractionResult> = this.process(snapshot, mounts, workSignal, options)
+      .finally(() => { this.inflight.delete(attempt) })
+    this.inflight.add(attempt)
+    return attempt
+  }
+
+  isClosing(): boolean {
+    return this.closing
   }
 
   async close(): Promise<void> {
     this.closing = true
     this.shutdown.abort(new Error('dsh-knowledge is shutting down'))
+    if (this.inflight.size === 0) return
+    const grace = new Promise<void>(resolve => {
+      const timer = setTimeout(resolve, EXTRACTION_CLOSE_GRACE_MS)
+      if (typeof timer.unref === 'function') timer.unref()
+    })
+    await Promise.race([Promise.allSettled([...this.inflight]), grace])
   }
 
   private async process(
     snapshot: TurnSnapshot,
     mounts: ResolvedKnowledgeMount[],
     signal: AbortSignal,
+    options: ExtractionRunOptions,
   ): Promise<ExtractionResult> {
-    if (!await this.provider.claimExtraction(snapshot.sourceKey, signal)) return emptyResult('duplicate')
+    if (!await this.provider.claimExtraction(snapshot.sourceKey, signal, options.leaseMs)) return emptyResult('duplicate')
     try {
       const groups = groupMountsByRoute(mounts, this.config, snapshot, this.clientRoute())
       const proposals: CandidateProposal[] = []
+      const timeoutMs = options.timeoutMs ?? this.config.extractionTimeoutMs
+      const abortReason = this.config.extractionMode === 'inline'
+        ? '回合已中断，知识提取已取消'
+        : '知识提取被中止（插件正在关闭）'
       for (const group of groups) {
         const query = `${snapshot.userText}\n${snapshot.assistantText}`.slice(0, 4000)
         const existing = await findExistingEntries(
@@ -69,6 +108,8 @@ export class ExtractionCoordinator {
           group.route,
           group.writebackPolicy,
           signal,
+          timeoutMs,
+          abortReason,
         ))
       }
       const uniqueProposals = coalesceDocumentProposals(proposals)
@@ -192,8 +233,7 @@ function emptyResult(status: ExtractionResult['status']): ExtractionResult {
   return { status, candidateCount: 0, directCount: 0, auditCount: 0, bases: [] }
 }
 
-function snapshotTurn(session: SessionLike, turn: number, maxChars: number): TurnSnapshot | undefined {
-  let start = -1
+function snapshotTurn(session: SessionLike, turn: number, maxChars: number): TurnSnapshot | undefined {  let start = -1
   for (let index = session.events.length - 1; index >= 0; index -= 1) {
     const event = session.events[index]
     if (event?.type === 'turn/start' && event.data.turn === turn) { start = index; break }
@@ -232,6 +272,42 @@ function snapshotTurn(session: SessionLike, turn: number, maxChars: number): Tur
   }
 }
 
+/**
+ * Renders the pending extraction payload of a failed turn as a standalone
+ * Markdown rescue file. Intentionally uses an HTML comment for provenance
+ * (not YAML front matter) so the file can be re-imported as a knowledge
+ * document without tripping parseKnowledgeMarkdown validation.
+ */
+export function buildTurnExportMarkdown(session: SessionLike, turn: number, maxChars: number): string | undefined {
+  const snapshot = snapshotTurn(session, turn, maxChars)
+  if (snapshot === undefined) return undefined
+  const heading = firstNonEmptyLine(snapshot.userText).slice(0, 60).trim() || '回写失败导出'
+  const exportedAt = new Date().toISOString().slice(0, 19).replace('T', ' ')
+  return [
+    `<!-- dsh-knowledge: session=${snapshot.sessionId} turn=${snapshot.turn} exportedAt=${exportedAt} -->`,
+    `# ${heading}`,
+    '',
+    `> 来源：DSH 会话 ${snapshot.sessionId.slice(0, 8)} 第 ${snapshot.turn} 轮（${exportedAt}）· dsh-knowledge 导出`,
+    '',
+    '## 用户提问',
+    '',
+    snapshot.userText,
+    '',
+    '## 助手回答',
+    '',
+    snapshot.assistantText,
+    '',
+  ].join('\n')
+}
+
+function firstNonEmptyLine(text: string): string {
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trim().replace(/^#{1,6}\s+/u, '')
+    if (trimmed.length > 0) return trimmed
+  }
+  return ''
+}
+
 async function extractWithLlm(
   ctx: RuntimeContextLike,
   config: ResolvedConfig,
@@ -241,6 +317,8 @@ async function extractWithLlm(
   route: { provider: string; model: string },
   writebackPolicy: KnowledgeWritebackPolicy,
   parentSignal: AbortSignal,
+  timeoutMs: number,
+  abortReason: string,
 ): Promise<CandidateProposal[]> {
   const defaultScope: KnowledgeScope = config.defaultScope === 'project' && snapshot.projectId !== undefined
     ? { kind: 'project', id: snapshot.projectId }
@@ -279,8 +357,8 @@ async function extractWithLlm(
   }
   const output = await callStructuredModel(
     ctx, route, message, snapshot.sessionId, config.extractionMaxTokens,
-    config.extractionTimeoutMs, parentSignal,
-    extractionSystemPrompt(writebackPolicy), extractionRetrySystemPrompt(writebackPolicy), 'extraction',
+    timeoutMs, parentSignal,
+    extractionSystemPrompt(writebackPolicy), extractionRetrySystemPrompt(writebackPolicy), 'extraction', abortReason,
   )
   const parsed = parseJsonOutput(output)
   const items = Array.isArray(parsed) ? parsed : isRecord(parsed) && Array.isArray(parsed.candidates) ? parsed.candidates : []
@@ -367,9 +445,17 @@ async function callExtractionModel(
   parentSignal: AbortSignal,
   system: string,
   reasoningEffort?: 'low',
+  abortReason = '知识提取被中止',
 ): Promise<{ text: string; finish?: { kind: string; failure?: { message?: string } } }> {
   const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(new Error('knowledge extraction timed out')), timeoutMs)
+  let timedOut = false
+  const timeout = timeoutMs > 0
+    ? setTimeout(() => {
+      timedOut = true
+      controller.abort(new Error(`knowledge extraction timed out after ${timeoutMs}ms`))
+    }, timeoutMs)
+    : undefined
+  if (timeout !== undefined && typeof timeout.unref === 'function') timeout.unref()
   const signal = AbortSignal.any([parentSignal, controller.signal])
   let deltas = ''
   let completedText = ''
@@ -390,8 +476,16 @@ async function callExtractionModel(
       if (chunk.type === 'block-end' && 'block' in chunk && chunk.block.type === 'text') completedText += chunk.block.text ?? ''
       if (chunk.type === 'finish' && 'reason' in chunk) finish = chunk.reason
     }
+  } catch (error) {
+    // pi-ai collapses every abort into a generic error and drops signal.reason,
+    // so the timeout budget and the interrupt path are re-derived here.
+    if (timedOut && controller.signal.aborted && !parentSignal.aborted) {
+      throw new Error(`知识提取超时（预算 ${Math.round(timeoutMs / 1000)} 秒）`)
+    }
+    if (parentSignal.aborted) throw new Error(abortReason)
+    throw error
   } finally {
-    clearTimeout(timeout)
+    if (timeout !== undefined) clearTimeout(timeout)
   }
   return {
     text: deltas.length > 0 ? deltas : completedText,
@@ -410,9 +504,11 @@ async function callStructuredModel(
   system: string,
   retrySystem: string,
   operation: string,
+  abortReason: string,
 ): Promise<string> {
   const first = await callExtractionModel(
     ctx, route, message, sessionId, maxTokens, timeoutMs, parentSignal, system,
+    undefined, abortReason,
   )
   if (first.finish === undefined || first.finish.kind === 'stop') return first.text
   if (first.finish.kind !== 'max-tokens') {
@@ -421,7 +517,7 @@ async function callStructuredModel(
   const retryBudget = Math.min(8192, Math.max(maxTokens, maxTokens * 2))
   ctx.logger.warn(`dsh-knowledge: ${route.provider}/${route.model} hit ${maxTokens} tokens during ${operation}; retrying with low reasoning and ${retryBudget}`)
   const retry = await callWithLowReasoningFallback(
-    ctx, route, message, sessionId, retryBudget, timeoutMs, parentSignal, retrySystem,
+    ctx, route, message, sessionId, retryBudget, timeoutMs, parentSignal, retrySystem, abortReason,
   )
   if (retry.finish !== undefined && retry.finish.kind !== 'stop') {
     throw new Error(retry.finish.failure?.message ?? `${operation} model ended with ${retry.finish.kind}`)
@@ -438,11 +534,12 @@ async function callWithLowReasoningFallback(
   timeoutMs: number,
   parentSignal: AbortSignal,
   system: string,
+  abortReason: string,
 ): Promise<{ text: string; finish?: { kind: string; failure?: { message?: string } } }> {
   try {
     return await callExtractionModel(
       ctx, route, message, sessionId, maxTokens, timeoutMs, parentSignal,
-      system, 'low',
+      system, 'low', abortReason,
     )
   } catch (error) {
     const messageText = error instanceof Error ? error.message : String(error)
@@ -450,7 +547,7 @@ async function callWithLowReasoningFallback(
     ctx.logger.warn(`dsh-knowledge: ${route.provider}/${route.model} does not accept reasoningEffort; retrying without it`)
     return callExtractionModel(
       ctx, route, message, sessionId, maxTokens, timeoutMs, parentSignal,
-      system,
+      system, undefined, abortReason,
     )
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 import type { Context } from '@deepseek-ai/cordis'
 import Schema from '@deepseek-ai/schemastery'
 import { randomBytes } from 'node:crypto'
+import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises'
+import { join as joinPath, sep as pathSep } from 'node:path'
 import { assertKnowledgeBrowserRequest, LOCAL_MANAGEMENT_API_PREFIX, registerKnowledgeApi } from './api.js'
 import {
   connectionSettingsBase,
@@ -14,7 +16,7 @@ import {
 import { Config as ConfigSchema, resolveConfig, type Config as KnowledgeConfig } from './config.js'
 import { KNOWLEDGE_SETTINGS_NAMESPACE } from './constants.js'
 import { registerKnowledgeControl, type KnowledgeConnectionUpdate } from './control.js'
-import { ExtractionCoordinator } from './extraction.js'
+import { ExtractionCoordinator, buildTurnExportMarkdown } from './extraction.js'
 import { LocalKnowledgeProvider } from './local-provider.js'
 import { registerRemoteManagementProxy } from './management-proxy.js'
 import type { KnowledgeProvider } from './provider.js'
@@ -31,6 +33,7 @@ import { registerKnowledgeWeb } from './web.js'
 
 export const Config = ConfigSchema
 export type Config = KnowledgeConfig
+export { resolveConfig } from './config.js'
 export * from './domain.js'
 export * from './provider.js'
 export * from './notes/domain.js'
@@ -88,10 +91,74 @@ export function apply(ctx: Context, config: KnowledgeConfig): void {
       ? { provider: clientSettings.writebackProvider, model: clientSettings.writebackModel }
       : undefined
   ))
-  type WritebackStatus = { status: 'running' | 'completed' | 'failed'; summary: string; error?: string; retryable: boolean }
+  type WritebackStatus = {
+    status: 'running' | 'completed' | 'failed'
+    summary: string
+    error?: string
+    retryable: boolean
+    export?: { fileName: string }
+  }
+  type WritebackPhase = 'initial' | 'auto' | 'final'
+  type WritebackRunOptions = { phase?: WritebackPhase; timeoutMs?: number; leaseMs?: number }
   const writebackStatuses = new Map<string, WritebackStatus>()
   const writebackSources = new Map<string, { agent: AgentLike; turn: number }>()
-  let runWriteback: (agent: AgentLike, turn: number, signal: AbortSignal) => Promise<WritebackStatus>
+  const writebackRetryTimers = new Map<string, ReturnType<typeof setTimeout>>()
+  const writebackAutoRetries = new Map<string, number>()
+  let runWriteback: (agent: AgentLike, turn: number, signal: AbortSignal, options?: WritebackRunOptions) => Promise<WritebackStatus>
+
+  const clearWritebackRetry = (key: string): void => {
+    const timer = writebackRetryTimers.get(key)
+    if (timer !== undefined) {
+      clearTimeout(timer)
+      writebackRetryTimers.delete(key)
+    }
+  }
+  const scheduleWritebackRetry = (key: string, delayMs: number, phase: 'auto' | 'final'): void => {
+    clearWritebackRetry(key)
+    const timer = setTimeout(() => {
+      writebackRetryTimers.delete(key)
+      void executeWritebackRetry(key, phase).catch(error => {
+        runtime.logger.warn(`dsh-knowledge: writeback retry chain error: ${error instanceof Error ? error.message : String(error)}`)
+      })
+    }, delayMs)
+    if (typeof timer.unref === 'function') timer.unref()
+    writebackRetryTimers.set(key, timer)
+  }
+  const executeWritebackRetry = async (key: string, phase: 'auto' | 'final'): Promise<void> => {
+    const source = writebackSources.get(key)
+    if (source === undefined || coordinator.isClosing()) return
+    if (phase === 'final') {
+      // The DB attempts<3 claim ceiling would block the fourth attempt; the
+      // reset mirrors the manual retry path before the final claim.
+      try { await provider.resetExtraction(key) } catch {}
+    }
+    const job = await provider.extractionJob(key).catch(() => undefined)
+    if (job?.status === 'completed') {
+      writebackStatuses.set(key, { status: 'completed', summary: '知识库回写 · 已处理', retryable: false })
+      writebackSources.delete(key)
+      writebackAutoRetries.delete(key)
+      return
+    }
+    if (job?.status === 'running') {
+      writebackStatuses.set(key, { status: 'running', summary: '知识库回写 · 正在其他路径处理', retryable: false })
+      return
+    }
+    await runWriteback(source.agent, source.turn, new AbortController().signal, {
+      phase,
+      ...(phase === 'final' ? { timeoutMs: resolved.extractionFinalTimeoutMs, leaseMs: resolved.extractionFinalTimeoutMs + 300_000 } : {}),
+    })
+  }
+  const exportFailedTurn = async (agent: AgentLike, turn: number): Promise<{ fileName?: string; skipped?: string }> => {
+    if (resolved.exportsDir === undefined) return { skipped: '未配置导出目录' }
+    const markdown = buildTurnExportMarkdown(agent.session, turn, resolved.extractionMaxInputChars)
+    if (markdown === undefined) return { skipped: '回合内容为空' }
+    await mkdir(resolved.exportsDir, { recursive: true })
+    const prefix = `回写失败-${turn}-`
+    const existing = await readdir(resolved.exportsDir).catch(() => [] as string[])
+    const fileName = existing.find(name => name.startsWith(prefix) && name.endsWith('.md')) ?? `${prefix}${exportTimestamp()}.md`
+    if (!existing.includes(fileName)) await writeFile(joinPath(resolved.exportsDir, fileName), markdown, 'utf8')
+    return { fileName }
+  }
   const handleCodec = new KnowledgeHandleCodec(randomBytes(32))
   const noteHandleCodec = new KnowledgeNoteHandleCodec(randomBytes(32))
   const managementEmbedToken = randomBytes(32).toString('base64url')
@@ -281,15 +348,15 @@ export function apply(ctx: Context, config: KnowledgeConfig): void {
             if (state?.status !== 'failed' || !state.retryable || source === undefined) {
               throw connectionError(409, 'writeback is not retryable')
             }
-            writebackStatuses.set(key, { status: 'running', summary: '知识库回写 · 正在重试', retryable: false })
-            try {
-              await provider.resetExtraction(key)
-              state = await runWriteback(source.agent, source.turn, new AbortController().signal)
-            } catch (error) {
-              const message = error instanceof Error ? error.message : String(error)
-              state = { status: 'failed', summary: '知识库回写 · 重试失败', error: message, retryable: true }
-              writebackStatuses.set(key, state)
-            }
+            clearWritebackRetry(key)
+            writebackAutoRetries.set(key, 0)
+            try { await provider.resetExtraction(key) } catch {}
+            writebackStatuses.set(key, { status: 'running', summary: '知识库回写 · 正在重试（手动）', retryable: false })
+            // The manual retry restarts the full chain (2 timed backoff
+            // attempts + the extended-budget final attempt) in the background;
+            // the client polls GET writeback-status for progression.
+            void runWriteback(source.agent, source.turn, new AbortController().signal).catch(() => {})
+            state = writebackStatuses.get(key)
           }
           res.writeHead(state === undefined ? 404 : 200, {
             'content-type': 'application/json; charset=utf-8',
@@ -301,6 +368,39 @@ export function apply(ctx: Context, config: KnowledgeConfig): void {
       },
     })
     if (disposeWritebackStatus !== undefined) httpRuntime.effect(() => disposeWritebackStatus, 'dsh-knowledge.writeback-status')
+    const disposeWritebackExport = httpRuntime.webServer?.register({
+      kind: 'exact',
+      path: '/knowledge-control/v1/writeback-export',
+      async handler(req, res) {
+        try {
+          if (req.method !== 'GET') { res.writeHead(405, { allow: 'GET' }).end(); return }
+          assertKnowledgeBrowserRequest(req, 'conversation-web')
+          const url = new URL(req.url ?? '/', 'http://localhost')
+          const sessionId = url.searchParams.get('sessionId')?.trim()
+          const turn = Number(url.searchParams.get('turn'))
+          if (!sessionId || !Number.isInteger(turn) || turn < 0) throw connectionError(400, 'sessionId and a non-negative integer turn are required')
+          const fileName = writebackStatuses.get(`${sessionId}:${turn}`)?.export?.fileName
+          if (resolved.exportsDir === undefined || fileName === undefined) {
+            throw connectionError(404, '没有可下载的失败导出文件')
+          }
+          const directory = joinPath(resolved.exportsDir)
+          const target = joinPath(directory, fileName)
+          if (fileName.includes('/') || fileName.includes('\\') || fileName.includes('..') || !target.startsWith(`${directory}${pathSep}`)) {
+            throw connectionError(400, '无效的导出文件名')
+          }
+          const content = await readFile(target).catch(() => undefined)
+          if (content === undefined) throw connectionError(404, '导出文件已不存在')
+          res.writeHead(200, {
+            'content-type': 'text/markdown; charset=utf-8',
+            'content-disposition': `attachment; filename*=UTF-8''${encodeURIComponent(fileName)}`,
+            'cache-control': 'no-store',
+          }).end(content)
+        } catch (error) {
+          sendControlError(res, error)
+        }
+      },
+    })
+    if (disposeWritebackExport !== undefined) httpRuntime.effect(() => disposeWritebackExport, 'dsh-knowledge.writeback-export')
     const disposeModelCatalog = httpRuntime.webServer?.register({
       kind: 'exact', path: '/knowledge-control/v1/models',
       async handler(req, res) {
@@ -328,54 +428,117 @@ export function apply(ctx: Context, config: KnowledgeConfig): void {
   }
 
   if (resolved.extractionEnabled) {
-    runWriteback = async (agent: AgentLike, turn: number, signal: AbortSignal): Promise<WritebackStatus> => {
+    runWriteback = async (agent, turn, signal, options = {}) => {
       const key = `${agent.session.id}:${turn}`
-      writebackStatuses.set(key, { status: 'running', summary: '知识库回写 · 正在重试', retryable: false })
+      const phase = options.phase ?? 'initial'
+      const runningSummary = phase === 'initial'
+        ? '知识库回写 · 正在回写'
+        : phase === 'auto'
+          ? `知识库回写 · 自动重试（${writebackAutoRetries.get(key) ?? 0}/2）`
+          : '知识库回写 · 最后一次尝试（30 分钟预算）'
+      writebackStatuses.set(key, { status: 'running', summary: runningSummary, retryable: false })
       let state: WritebackStatus
       try {
-        const result = await coordinator.run(agent.session, turn, signal)
+        const result = await coordinator.run(agent.session, turn, signal, options)
         let summary: string
         if (result.status === 'duplicate') {
           const job = await provider.extractionJob(key, signal)
           if (job?.status === 'failed') throw new Error(job.lastError ?? '知识库回写失败')
           summary = '知识库回写 · 已处理'
         } else if (result.status === 'unmounted') summary = '知识库回写 · 未挂载可写知识库'
-        else if (result.status === 'skipped') summary = '知识库回写 · 当前回答无可提取内容'
-        else if (result.candidateCount === 0) summary = '知识库回写 · 无需收录'
+        else if (result.status === 'skipped') {
+          // During shutdown run() short-circuits to 'skipped'; that must not
+          // be reported as a successful no-op writeback.
+          if (coordinator.isClosing()) throw new Error('插件正在关闭，回写中止')
+          summary = '知识库回写 · 当前回答无可提取内容'
+        } else if (result.candidateCount === 0) summary = '知识库回写 · 无需收录'
         else summary = `知识库回写 · ${result.bases.map(base => {
           const parts = [base.directCount > 0 ? `直写 ${base.directCount}` : '', base.auditCount > 0 ? `待审 ${base.auditCount}` : ''].filter(Boolean)
           return `${base.name}：${parts.join('、')}`
         }).join('；')}`
+        if (phase !== 'initial') summary = `${summary}（自动重试后成功）`
         state = { status: 'completed', summary, retryable: false }
+        clearWritebackRetry(key)
         writebackSources.delete(key)
+        writebackAutoRetries.delete(key)
       } catch (error) {
-        if (signal.aborted) throw error
         const message = error instanceof Error ? error.message : String(error)
-        runtime.logger.warn(`dsh-knowledge: synchronous writeback failed: ${message}`)
+        runtime.logger.warn(`dsh-knowledge: writeback attempt failed (phase ${phase}): ${message}`)
         const job = await provider.extractionJob(key).catch(() => undefined)
         const retryable = job?.status === 'failed'
-        const summary = message.includes('max-tokens')
-          ? '知识库回写 · 失败：提取结果超过模型输出上限'
-          : '知识库回写 · 失败'
-        state = { status: 'failed', summary, error: message, retryable }
         if (retryable) writebackSources.set(key, { agent: snapshotAgent(agent), turn })
         else writebackSources.delete(key)
+        // Terminalize first in every path: an aborted or closing run must
+        // never leave the UI status stuck on 'running' (the historical bug).
+        const interrupted = signal.aborted
+        const chainActive = retryable && !interrupted && !coordinator.isClosing()
+        if (chainActive && phase !== 'final') {
+          const autoRetries = writebackAutoRetries.get(key) ?? 0
+          if (autoRetries < resolved.extractionRetryDelaysMs.length) {
+            writebackAutoRetries.set(key, autoRetries + 1)
+            const delayMs = resolved.extractionRetryDelaysMs[autoRetries] ?? 60_000
+            state = { status: 'running', summary: `知识库回写 · 将在 ${Math.round(delayMs / 1000)} 秒后自动重试（${autoRetries + 1}/2）`, retryable: false }
+            scheduleWritebackRetry(key, delayMs, 'auto')
+          } else {
+            state = { status: 'running', summary: `知识库回写 · 将在 ${Math.round(resolved.extractionFinalRetryDelayMs / 1000)} 秒后进行最后一次尝试（30 分钟预算）`, retryable: false }
+            scheduleWritebackRetry(key, resolved.extractionFinalRetryDelayMs, 'final')
+          }
+        } else if (chainActive && phase === 'final') {
+          // The whole automatic chain is exhausted: persist the pending
+          // extraction payload as a rescue Markdown file, then surface the
+          // retry button.
+          const exported = await exportFailedTurn(agent, turn).catch((exportError): { fileName?: string; skipped?: string } => ({
+            skipped: exportError instanceof Error ? exportError.message : String(exportError),
+          }))
+          state = {
+            status: 'failed',
+            summary: message.includes('max-tokens')
+              ? '知识库回写 · 自动重试后仍失败：提取结果超过模型输出上限'
+              : '知识库回写 · 自动重试后仍失败',
+            error: exported.skipped !== undefined ? `${message}（导出跳过：${exported.skipped}）` : message,
+            retryable: true,
+            ...exported.fileName !== undefined ? { export: { fileName: exported.fileName } } : {},
+          }
+        } else {
+          state = {
+            status: 'failed',
+            summary: interrupted
+              ? '知识库回写 · 失败：回合已中断，可手动重试'
+              : message.includes('max-tokens')
+                ? '知识库回写 · 失败：提取结果超过模型输出上限'
+                : '知识库回写 · 失败',
+            error: message,
+            retryable,
+          }
+        }
       }
       writebackStatuses.set(key, state)
       if (writebackStatuses.size > 1000) {
         const oldest = writebackStatuses.keys().next().value as string
         writebackStatuses.delete(oldest)
         writebackSources.delete(oldest)
+        clearWritebackRetry(oldest)
+        writebackAutoRetries.delete(oldest)
       }
       runtime.logger.info(`dsh-knowledge: ${state.summary}`)
       return state
     }
     runtime.on('agent/turn-stopping', async ({ agent, turn, signal }) => {
-      await runWriteback(agent, turn, signal).catch(() => {})
+      if (resolved.extractionMode === 'inline') {
+        // Legacy behavior: keep awaiting so the turn completes only after the
+        // synchronous writeback attempt settles.
+        await runWriteback(agent, turn, signal).then(() => undefined, () => {})
+        return
+      }
+      // Detached: the writeback is fire-and-forget with its own signal, so a
+      // user follow-up that cancels the turn cannot abort the extraction.
+      void runWriteback(agent, turn, new AbortController().signal).catch(() => {})
     })
   }
 
   runtime.effect(() => async () => {
+    for (const timer of writebackRetryTimers.values()) clearTimeout(timer)
+    writebackRetryTimers.clear()
     await coordinator.close()
     await providerRouter.close()
     await managementProvider?.close()
@@ -392,6 +555,12 @@ function snapshotAgent(agent: AgentLike): AgentLike {
       events: [...agent.session.events],
     },
   }
+}
+
+function exportTimestamp(): string {
+  const now = new Date()
+  const pad = (value: number): string => String(value).padStart(2, '0')
+  return `${pad(now.getMonth() + 1)}${pad(now.getDate())}-${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`
 }
 
 function publicConnectionError(error: unknown): Error {

--- a/src/local-provider.ts
+++ b/src/local-provider.ts
@@ -1370,10 +1370,10 @@ export class LocalKnowledgeProvider implements KnowledgeProvider {
     return reviewed
   }
 
-  async claimExtraction(sourceKey: string): Promise<boolean> {
+  async claimExtraction(sourceKey: string, signal?: AbortSignal, leaseMs: number = EXTRACTION_LEASE_MS): Promise<boolean> {
     this.assertOpen()
     const claimedAt = nowIso()
-    const staleBefore = new Date(Date.now() - EXTRACTION_LEASE_MS).toISOString()
+    const staleBefore = new Date(Date.now() - leaseMs).toISOString()
     const result = this.db.prepare(`
       INSERT INTO extraction_jobs(source_key,status,attempts,candidate_count,updated_at)
       VALUES(?,'running',1,0,?)

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -81,7 +81,7 @@ export interface KnowledgeProvider {
   writeDirect(proposal: CandidateProposal, sourceKey?: string, signal?: AbortSignal): Promise<DirectWriteResult>
   listCandidates(status: 'pending' | 'approved' | 'rejected', limit: number, signal?: AbortSignal): Promise<KnowledgeCandidate[]>
   review(id: string, decision: ReviewDecision, signal?: AbortSignal): Promise<KnowledgeCandidate>
-  claimExtraction(sourceKey: string, signal?: AbortSignal): Promise<boolean>
+  claimExtraction(sourceKey: string, signal?: AbortSignal, leaseMs?: number): Promise<boolean>
   completeExtraction(sourceKey: string, candidateCount: number, signal?: AbortSignal): Promise<void>
   failExtraction(sourceKey: string, error: string, signal?: AbortSignal): Promise<void>
   resetExtraction(sourceKey: string, signal?: AbortSignal): Promise<void>

--- a/src/web.ts
+++ b/src/web.ts
@@ -11,6 +11,7 @@ interface Asset {
 const STATIC_ASSETS = new Map<string, Asset>([
   ['app.js', loadAsset('../web/app.js', 'text/javascript; charset=utf-8')],
   ['change-review.js', loadAsset('../web/change-review.js', 'text/javascript; charset=utf-8')],
+  ['import-utils.js', loadAsset('../web/import-utils.js', 'text/javascript; charset=utf-8')],
   ['markdown-preview.js', loadAsset('../web/markdown-preview.js', 'text/javascript; charset=utf-8')],
   ['note-editor.js', loadAsset('../web/note-editor.js', 'text/javascript; charset=utf-8')],
   ['workspace-effects.js', loadAsset('../web/workspace-effects.js', 'text/javascript; charset=utf-8')],

--- a/test/connection.test.mjs
+++ b/test/connection.test.mjs
@@ -66,6 +66,6 @@ test('connection settings survive restart in a private atomic file', async (t) =
   }
   await storeConnection(path, settings)
   assert.deepEqual(loadStoredConnection(path), settings)
-  assert.equal((await stat(path)).mode & 0o777, 0o600)
+  if (process.platform !== 'win32') assert.equal((await stat(path)).mode & 0o777, 0o600)
   assert.match(await readFile(path, 'utf8'), /restart_remote_token/)
 })

--- a/test/cordis-integration.test.mjs
+++ b/test/cordis-integration.test.mjs
@@ -53,12 +53,17 @@ test('real Cordis context dynamically mounts API and Web routes', async (t) => {
     ['prefix', '/knowledge-api/v1'],
     ['exact', '/knowledge-control/v1/connection'],
     ['exact', '/knowledge-control/v1/writeback-status'],
+    ['exact', '/knowledge-control/v1/writeback-export'],
     ['exact', '/knowledge-control/v1/models'],
   ])
 
   const server = createServer((req, res) => {
     const pathname = new URL(req.url, 'http://localhost').pathname
+    // Mirror the real webServer dispatch: exact routes win, then the longest
+    // registered prefix route serves the request (e.g. the /knowledge assets).
     const route = routes.find(candidate => candidate.kind === 'exact' && candidate.path === pathname)
+      ?? routes.filter(candidate => candidate.kind === 'prefix' && pathname.startsWith(candidate.path))
+        .sort((a, b) => b.path.length - a.path.length)[0]
     if (route === undefined) return res.writeHead(404).end()
     void route.handler(req, res)
   })
@@ -79,4 +84,12 @@ test('real Cordis context dynamically mounts API and Web routes', async (t) => {
   assert.equal((await fetch(endpoint('/knowledge-control/v1/writeback-status?sessionId=s&turn=1'), {
     headers: { 'x-dsh-knowledge-client': 'conversation-web' },
   })).status, 404)
+
+  // The markdown-import helper is loaded at runtime via dynamic import(); it
+  // must be served as a real static module or the 导入文件 button breaks.
+  const importUtils = await fetch(endpoint('/knowledge/import-utils.js?v=test'))
+  assert.equal(importUtils.status, 200)
+  assert.match(importUtils.headers.get('content-type') ?? '', /text\/javascript/)
+  assert.match(await importUtils.text(), /splitMarkdownByH2/)
+  assert.equal((await fetch(endpoint('/knowledge/missing-asset.js'))).status, 404)
 })

--- a/test/local-provider.test.mjs
+++ b/test/local-provider.test.mjs
@@ -12,7 +12,17 @@ async function fixture(t) {
   provider.fixtureRoot = root
   t.after(async () => {
     await provider.close()
-    await rm(root, { recursive: true, force: true })
+    // Windows releases SQLite file handles asynchronously after close(); a
+    // plain immediate rm() races with that and fails with EBUSY.
+    for (let attempt = 0; ; attempt += 1) {
+      try {
+        await rm(root, { recursive: true, force: true })
+        break
+      } catch (error) {
+        if (attempt >= 10 || error?.code !== 'EBUSY') throw error
+        await new Promise(resolve => setTimeout(resolve, 50))
+      }
+    }
   })
   return provider
 }
@@ -332,6 +342,9 @@ test('audit approval merges a same-topic candidate into its document', async (t)
   assert.match(afterRestart?.body || '', /## 兼容性风险/)
   assert.equal((await reopened.search({ text: '旧版配置兼容性风险', limit: 10 }))[0]?.entry.id, existing.id)
   assert.equal((await reopened.listDocuments('default')).length, 1)
+  // The fixture's FIFO after-hook rm() runs before reopened's own t.after,
+  // so close the second connection here to release the database files.
+  await reopened.close()
 })
 
 test('concurrent review treats distinct document sections as compatible additions', async (t) => {

--- a/test/plugin-runtime.test.mjs
+++ b/test/plugin-runtime.test.mjs
@@ -1,9 +1,10 @@
 import assert from 'node:assert/strict'
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import test from 'node:test'
-import { apply, LocalKnowledgeProvider } from '../lib/index.js'
+import { apply, LocalKnowledgeProvider, resolveConfig } from '../lib/index.js'
+import { IMPORT_MAX_BODY_CHARS, splitMarkdownByH2, titleFromMarkdown } from '../web/import-utils.js'
 
 test('plugin gates completed-turn extraction and keeps knowledge surface messages out of model input', async (t) => {
   const root = await mkdtemp(join(tmpdir(), 'dsh-knowledge-runtime-'))
@@ -61,10 +62,22 @@ test('plugin gates completed-turn extraction and keeps knowledge surface message
     backend: 'local', databasePath, remoteTimeoutMs: 5000, exposeApi: false,
     apiPrefix: '/knowledge-api/v1', extractionEnabled: true, extractionMaxTokens: 1000,
     extractionTimeoutMs: 5000, extractionMaxInputChars: 10000, defaultScope: 'project',
+    extractionMode: 'inline',
   })
   t.after(async () => {
+    // node:test after-hooks run in registration order (FIFO): close the
+    // harness observer before rm() tries to unlink the WAL database files.
+    try { await observer.close() } catch {}
     for (const dispose of disposers.reverse()) await dispose()
-    await rm(root, { recursive: true, force: true })
+    for (let attempt = 0; ; attempt += 1) {
+      try {
+        await rm(root, { recursive: true, force: true })
+        break
+      } catch (error) {
+        if (attempt >= 10 || error?.code !== 'EBUSY') throw error
+        await new Promise(resolve => setTimeout(resolve, 50))
+      }
+    }
   })
 
   const user = { id: 'u1', role: 'user', content: [{ type: 'text', text: 'How do I install a DSH plugin?' }], source: { kind: 'user' } }
@@ -310,10 +323,21 @@ test('conservative write-back accepts durable source-backed GitHub research with
     backend: 'local', databasePath, remoteTimeoutMs: 5000, exposeApi: false,
     apiPrefix: '/knowledge-api/v1', extractionEnabled: true, extractionMaxTokens: 1200,
     extractionTimeoutMs: 5000, extractionMaxInputChars: 10000, defaultScope: 'global',
+    extractionMode: 'inline',
   })
   t.after(async () => {
+    // FIFO after-hooks: close the harness observer before rm() unlinks the WAL db.
+    try { await observer.close() } catch {}
     for (const dispose of disposers.reverse()) await dispose()
-    await rm(root, { recursive: true, force: true })
+    for (let attempt = 0; ; attempt += 1) {
+      try {
+        await rm(root, { recursive: true, force: true })
+        break
+      } catch (error) {
+        if (attempt >= 10 || error?.code !== 'EBUSY') throw error
+        await new Promise(resolve => setTimeout(resolve, 50))
+      }
+    }
   })
 
   const observer = new LocalKnowledgeProvider(databasePath)
@@ -375,7 +399,15 @@ test('content write-back is not exposed to the main agent tool surface', async (
   })
   t.after(async () => {
     for (const dispose of disposers.reverse()) await dispose()
-    await rm(root, { recursive: true, force: true })
+    for (let attempt = 0; ; attempt += 1) {
+      try {
+        await rm(root, { recursive: true, force: true })
+        break
+      } catch (error) {
+        if (attempt >= 10 || error?.code !== 'EBUSY') throw error
+        await new Promise(resolve => setTimeout(resolve, 50))
+      }
+    }
   })
 
   assert.equal(tools.has('knowledge_write'), false)
@@ -462,10 +494,21 @@ test('direct write approves all non-conflicts and skips unmounted sessions', asy
     backend: 'local', databasePath, remoteTimeoutMs: 5000, exposeApi: false,
     apiPrefix: '/knowledge-api/v1', extractionEnabled: true, extractionMaxTokens: 1200,
     extractionTimeoutMs: 5000, extractionMaxInputChars: 10000, defaultScope: 'project',
+    extractionMode: 'inline',
   })
   t.after(async () => {
+    // FIFO after-hooks: close the harness observer before rm() unlinks the WAL db.
+    try { await observer.close() } catch {}
     for (const dispose of disposers.reverse()) await dispose()
-    await rm(root, { recursive: true, force: true })
+    for (let attempt = 0; ; attempt += 1) {
+      try {
+        await rm(root, { recursive: true, force: true })
+        break
+      } catch (error) {
+        if (attempt >= 10 || error?.code !== 'EBUSY') throw error
+        await new Promise(resolve => setTimeout(resolve, 50))
+      }
+    }
   })
 
   const sessionFor = (id, turn) => ({
@@ -522,4 +565,293 @@ test('direct write approves all non-conflicts and skips unmounted sessions', asy
   assert.equal(updatedExisting.type, 'decision')
   assert.match(updatedExisting.body, /Operational note/)
   assert.equal(direct.events.at(-1).type, 'assistant/message')
+})
+
+const WRITEBACK_SUCCESS_CANDIDATES = { candidates: [{
+  action: 'create', knowledgeBaseId: 'default', title: 'Durable writeback conclusion',
+  body: 'The durable conclusion is confirmed for reuse.', type: 'fact', tags: ['wb'],
+  scope: { kind: 'project', id: '/workspace/demo' }, confidence: 0.93,
+  retention: { durable: true, evidence: 'explicit' }, reason: 'Confirmed durable conclusion.',
+}] }
+
+function createControlResponse() {
+  const response = { status: 0, headers: {}, body: '' }
+  response.writeHead = (status, headers) => {
+    response.status = status
+    response.headers = headers ?? {}
+    return { end: body => { response.body = body ?? '' } }
+  }
+  response.end = body => { response.body = body ?? '' }
+  return response
+}
+
+async function controlCall(routes, path, { method = 'GET', url = '/', headers = {}, parseJson = true } = {}) {
+  const route = routes.get(path)
+  assert.ok(route, `missing registered route ${path}`)
+  const response = createControlResponse()
+  await route.handler({ method, url, headers }, response)
+  const body = parseJson ? JSON.parse(response.body || '{}') : response.body
+  return { status: response.status, headers: response.headers, body }
+}
+
+const writebackStatusCall = (routes, sessionId, turn, method = 'GET') => controlCall(routes, '/knowledge-control/v1/writeback-status', {
+  method,
+  url: `/knowledge-control/v1/writeback-status?sessionId=${sessionId}&turn=${turn}`,
+  headers: { 'x-dsh-knowledge-client': 'conversation-web' },
+})
+
+async function waitFor(predicate, timeoutMs = 8000) {
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    if (await predicate()) return true
+    await new Promise(resolve => setTimeout(resolve, 25))
+  }
+  return false
+}
+
+function writebackSession(id, turn) {
+  return {
+    id, header: { cwd: '/workspace/demo' }, events: [
+      { type: 'turn/start', seq: 0, data: { turn } },
+      { type: 'user/message', seq: 1, data: { id: `u-${id}`, role: 'user', content: [{ type: 'text', text: 'Record the durable conclusion for the knowledge base.' }], source: { kind: 'user' } } },
+      { type: 'assistant/message', seq: 2, data: { turn, message: {
+        id: `a-${id}`, role: 'assistant', content: [{ type: 'text', text: 'The durable conclusion is confirmed for reuse.' }],
+        source: { kind: 'model', provider: 'mock', model: 'extractor' },
+      } } },
+    ],
+    append(type, data, options) { const event = { type, seq: this.events.length, data, ...options }; this.events.push(event); return event },
+  }
+}
+
+async function startWritebackHarness(t, { llm, extractionMode = 'detached', extractionTimeoutMs = 5000, retryDelays = [10, 10], finalDelay = 10, finalTimeoutMs = 5000 } = {}) {
+  const root = await mkdtemp(join(tmpdir(), 'dsh-knowledge-wb-'))
+  const databasePath = join(root, 'knowledge.sqlite')
+  const listeners = new Map()
+  const disposers = []
+  const routes = new Map()
+  const ctx = {
+    logger: { debug() {}, info() {}, warn() {}, error() {} },
+    llm,
+    tools: { register() { return () => {} } },
+    on(name, listener) { listeners.set(name, listener); return () => listeners.delete(name) },
+    effect(factory) { disposers.push(factory()) },
+    get() { return undefined },
+    webServer: { register(route) { routes.set(route.path, route); return () => routes.delete(route.path) } },
+  }
+  apply(ctx, {
+    backend: 'local', databasePath, remoteTimeoutMs: 5000, exposeApi: false,
+    apiPrefix: '/knowledge-api/v1', extractionEnabled: true, extractionMaxTokens: 1000,
+    extractionTimeoutMs, extractionMaxInputChars: 10000, defaultScope: 'project',
+    extractionMode,
+    extractionRetryDelaysMs: retryDelays,
+    extractionFinalRetryDelayMs: finalDelay,
+    extractionFinalTimeoutMs: finalTimeoutMs,
+  })
+  t.after(async () => {
+    // node:test after-hooks run in registration order (FIFO): close the
+    // harness observer before the disposers' rm() tries to unlink the WAL db.
+    try { await observer.close() } catch {}
+    for (const dispose of disposers.reverse()) await dispose()
+    for (let attempt = 0; ; attempt += 1) {
+      try {
+        await rm(root, { recursive: true, force: true })
+        break
+      } catch (error) {
+        if (attempt >= 10 || error?.code !== 'EBUSY') throw error
+        await new Promise(resolve => setTimeout(resolve, 50))
+      }
+    }
+  })
+  const observer = new LocalKnowledgeProvider(databasePath)
+  t.after(() => observer.close())
+  await observer.patchKnowledgeBase('default', { description: 'Reusable writeback harness knowledge.' })
+  await observer.upsertMount({
+    targetKind: 'project', targetId: '/workspace/demo', knowledgeBaseId: 'default',
+    enabled: true, recallEnabled: true, writeMode: 'audit', includeTags: [], excludeTags: [], extractionInstructions: '',
+  })
+  return { root, databasePath, listeners, routes, observer }
+}
+
+const successStream = counter => ({
+  async *stream() {
+    counter.calls += 1
+    yield { type: 'text-delta', text: JSON.stringify(WRITEBACK_SUCCESS_CANDIDATES) }
+    yield { type: 'finish', reason: { kind: 'stop' } }
+  },
+})
+
+test('detached writeback survives an aborted turn signal (user follow-up no longer kills writeback)', async (t) => {
+  const counter = { calls: 0 }
+  const { listeners, routes, observer } = await startWritebackHarness(t, { llm: successStream(counter) })
+  const controller = new AbortController()
+  listeners.get('agent/turn-stopping')({ agent: { session: writebackSession('detach-1', 1) }, turn: 1, signal: controller.signal })
+  controller.abort(new Error('user follow-up canceled the turn'))
+  assert.equal(await waitFor(async () => (await observer.extractionJob('detach-1:1'))?.status === 'completed'), true)
+  const state = await writebackStatusCall(routes, 'detach-1', 1)
+  assert.equal(state.body.status, 'completed')
+  assert.match(state.body.summary, /直写|待审|无需收录|已处理/)
+  assert.equal(counter.calls, 1)
+})
+
+test('failed writeback auto-retries once in the background and completes', async (t) => {
+  const counter = { calls: 0 }
+  const llm = {
+    async *stream() {
+      counter.calls += 1
+      if (counter.calls === 1) throw new Error('Request was aborted')
+      yield { type: 'text-delta', text: JSON.stringify(WRITEBACK_SUCCESS_CANDIDATES) }
+      yield { type: 'finish', reason: { kind: 'stop' } }
+    },
+  }
+  const { listeners, routes, observer } = await startWritebackHarness(t, { llm })
+  listeners.get('agent/turn-stopping')({ agent: { session: writebackSession('retry-1', 1) }, turn: 1, signal: new AbortController().signal })
+  assert.equal(await waitFor(async () => (await observer.extractionJob('retry-1:1'))?.status === 'completed'), true)
+  const job = await observer.extractionJob('retry-1:1')
+  assert.equal(job.attempts, 2)
+  const state = await writebackStatusCall(routes, 'retry-1', 1)
+  assert.equal(state.body.status, 'completed')
+  assert.match(state.body.summary, /自动重试后成功/)
+})
+
+test('inline writeback terminalizes failed+retryable when the turn signal is already aborted', async (t) => {
+  const llm = { async *stream() { throw new Error('Request was aborted') } }
+  const { listeners, routes, observer } = await startWritebackHarness(t, { llm, extractionMode: 'inline' })
+  const controller = new AbortController()
+  controller.abort(new Error('interrupt'))
+  await listeners.get('agent/turn-stopping')({ agent: { session: writebackSession('inline-1', 1) }, turn: 1, signal: controller.signal })
+  const state = await writebackStatusCall(routes, 'inline-1', 1)
+  assert.equal(state.body.status, 'failed')
+  assert.equal(state.body.retryable, true)
+  assert.match(state.body.summary, /回合已中断/)
+  const job = await observer.extractionJob('inline-1:1')
+  assert.equal(job?.status, 'failed')
+})
+
+test('automatic chain exhausts 2 backoff retries plus the final attempt, then fails retryable and exports the payload', async (t) => {
+  const counter = { calls: 0 }
+  const llm = { async *stream() { counter.calls += 1; throw new Error('Request was aborted') } }
+  const { root, listeners, routes, observer } = await startWritebackHarness(t, { llm })
+  listeners.get('agent/turn-stopping')({ agent: { session: writebackSession('chain-1', 1) }, turn: 1, signal: new AbortController().signal })
+  assert.equal(await waitFor(async () => (await writebackStatusCall(routes, 'chain-1', 1)).body.status === 'failed'), true)
+  const state = await writebackStatusCall(routes, 'chain-1', 1)
+  assert.equal(state.body.retryable, true)
+  assert.match(state.body.summary, /自动重试后仍失败/)
+  assert.equal(counter.calls, 4)
+  assert.equal((await observer.extractionJob('chain-1:1'))?.attempts, 1)
+  assert.ok(state.body.export?.fileName.startsWith('回写失败-1-'))
+  const exportsDir = join(root, 'exports')
+  const files = await readdir(exportsDir)
+  assert.equal(files.length, 1)
+  const markdown = await readFile(join(exportsDir, files[0]), 'utf8')
+  assert.match(markdown, /dsh-knowledge: session=chain-1 turn=1/)
+  assert.match(markdown, /## 用户提问/)
+  assert.match(markdown, /## 助手回答/)
+  const download = await controlCall(routes, '/knowledge-control/v1/writeback-export', {
+    url: '/knowledge-control/v1/writeback-export?sessionId=chain-1&turn=1',
+    headers: { 'x-dsh-knowledge-client': 'conversation-web' },
+    parseJson: false,
+  })
+  assert.equal(download.status, 200)
+  assert.match(String(download.headers['content-disposition']), /attachment/)
+  assert.match(String(download.body), /## 助手回答/)
+  const unauthorized = await controlCall(routes, '/knowledge-control/v1/writeback-export', {
+    url: '/knowledge-control/v1/writeback-export?sessionId=chain-1&turn=1',
+    headers: {},
+  })
+  assert.equal(unauthorized.status, 401)
+
+  // Manual retry restarts the full chain; the export file is reused, not duplicated.
+  const post = await writebackStatusCall(routes, 'chain-1', 1, 'POST')
+  assert.equal(post.body.status, 'running')
+  assert.equal(await waitFor(async () => (await writebackStatusCall(routes, 'chain-1', 1)).body.status === 'failed'), true)
+  const retried = await writebackStatusCall(routes, 'chain-1', 1)
+  assert.equal(retried.body.retryable, true)
+  assert.equal((await readdir(exportsDir)).length, 1)
+  assert.equal(retried.body.export?.fileName, state.body.export?.fileName)
+})
+
+test('extraction timeout surfaces a semantic timeout error instead of a generic abort', async (t) => {
+  const llm = {
+    async *stream(request) {
+      await new Promise((resolve, reject) => {
+        const signal = request.signal
+        if (signal?.aborted) { reject(new Error('Request was aborted')); return }
+        signal?.addEventListener('abort', () => reject(new Error('Request was aborted')), { once: true })
+      })
+      yield { type: 'finish', reason: { kind: 'stop' } }
+    },
+  }
+  const { listeners, routes, observer } = await startWritebackHarness(t, {
+    llm, extractionMode: 'inline', extractionTimeoutMs: 700, retryDelays: [10, 10], finalDelay: 10, finalTimeoutMs: 700,
+  })
+  listeners.get('agent/turn-stopping')({ agent: { session: writebackSession('timeout-1', 1) }, turn: 1, signal: new AbortController().signal })
+  assert.equal(await waitFor(async () => (await writebackStatusCall(routes, 'timeout-1', 1)).body.status === 'failed', 15000), true)
+  const state = await writebackStatusCall(routes, 'timeout-1', 1)
+  assert.match(state.body.error, /知识提取超时（预算 1 秒）/)
+  assert.equal((await observer.extractionJob('timeout-1:1'))?.status, 'failed')
+})
+
+test('inline mode keeps the synchronous writeback semantics for successful turns', async (t) => {
+  const counter = { calls: 0 }
+  const { listeners, observer, routes } = await startWritebackHarness(t, { llm: successStream(counter), extractionMode: 'inline' })
+  await listeners.get('agent/turn-stopping')({ agent: { session: writebackSession('inline-ok', 1) }, turn: 1, signal: new AbortController().signal })
+  assert.equal(counter.calls, 1)
+  assert.equal((await observer.extractionJob('inline-ok:1'))?.status, 'completed')
+  const state = await writebackStatusCall(routes, 'inline-ok', 1)
+  assert.equal(state.body.status, 'completed')
+})
+
+test('writeback chain configuration resolves detached mode, 300s budget, and export fallbacks', () => {
+  const base = {
+    backend: 'local', databasePath: join('x', 'knowledge.sqlite'), remoteTimeoutMs: 5000,
+    exposeApi: false, apiPrefix: '/knowledge-api/v1',
+  }
+  const defaults = resolveConfig(base)
+  assert.equal(defaults.extractionMode, 'detached')
+  assert.equal(defaults.extractionTimeoutMs, 300_000)
+  assert.equal(defaults.extractionFinalTimeoutMs, 1_800_000)
+  assert.equal(defaults.extractionFinalRetryDelayMs, 60_000)
+  assert.deepEqual(defaults.extractionRetryDelaysMs, [20_000, 60_000])
+  assert.equal(defaults.exportsDir, join('x', 'exports'))
+  const custom = resolveConfig({
+    ...base,
+    extractionRetryDelaysMs: [5, 'bad', 10, 999],
+    extractionFinalRetryDelayMs: 15,
+    extractionFinalTimeoutMs: 1200,
+    exportsDir: '  ',
+  })
+  assert.deepEqual(custom.extractionRetryDelaysMs, [5, 10])
+  assert.equal(custom.extractionFinalRetryDelayMs, 15)
+  assert.equal(custom.extractionFinalTimeoutMs, 1200)
+  assert.equal(custom.exportsDir, join('x', 'exports'))
+  const remote = resolveConfig({
+    backend: 'remote', remoteUrl: 'https://example.com/knowledge-api/v1',
+    remoteToken: 'x'.repeat(24), remoteTimeoutMs: 5000,
+  })
+  assert.equal(remote.exportsDir, undefined)
+  assert.equal(remote.extractionMode, 'detached')
+  const zero = resolveConfig({ ...base, extractionTimeoutMs: 0 })
+  assert.equal(zero.extractionTimeoutMs, 0)
+})
+
+test('markdown import helpers derive titles and split oversized bodies by H2 boundaries', () => {
+  assert.equal(titleFromMarkdown('deployment.md', ''), 'deployment')
+  assert.equal(titleFromMarkdown('note.markdown', '前言\n\n# 真标题\n'), 'note')
+  assert.equal(titleFromMarkdown('', '## H2 first'), 'H2 first')
+  assert.equal(titleFromMarkdown('x.md', '   \n# spaced\n'), 'spaced')
+  assert.equal(titleFromMarkdown('a/b/c.md', ''), 'a/b/c')
+
+  const body = `## A\n\n${'x'.repeat(30_000)}\n\n## B\n\n${'y'.repeat(30_000)}`
+  const chunks = splitMarkdownByH2(body)
+  assert.equal(chunks.length, 2)
+  assert.ok(chunks[0].startsWith('## A'))
+  assert.ok(chunks[1].startsWith('## B'))
+  assert.ok(chunks.every(chunk => chunk.length <= IMPORT_MAX_BODY_CHARS))
+
+  const exact = 'z'.repeat(IMPORT_MAX_BODY_CHARS)
+  assert.deepEqual(splitMarkdownByH2(exact), [exact])
+  const hardChunks = splitMarkdownByH2('w'.repeat(IMPORT_MAX_BODY_CHARS + 100))
+  assert.ok(hardChunks.length >= 2)
+  assert.ok(hardChunks.every(chunk => chunk.length <= IMPORT_MAX_BODY_CHARS))
+  assert.deepEqual(splitMarkdownByH2('   '), [])
 })

--- a/test/service-settings.test.mjs
+++ b/test/service-settings.test.mjs
@@ -16,5 +16,5 @@ test('client-local service and write-back model settings persist in a private at
     writebackProvider: 'cli',
     writebackModel: 'gpt-5.6-luna',
   })
-  assert.equal((await stat(path)).mode & 0o777, 0o600)
+  if (process.platform !== 'win32') assert.equal((await stat(path)).mode & 0o777, 0o600)
 })

--- a/test/web.test.mjs
+++ b/test/web.test.mjs
@@ -103,7 +103,7 @@ test('management console serves a secured same-origin application', async (t) =>
   assert.match(application, /libraryDetail/)
   assert.doesNotMatch(application, /inspectedKnowledgeBaseId/)
   assert.match(application, /mounts\/resolve/)
-  assert.match(application, /当前会话未挂载知识库/)
+  assert.match(application, /未挂载到当前会话/)
   assert.match(application, /confirmDeleteDocument/)
   assert.match(application, /openFinalizeDocument/)
   assert.match(application, /reopenDocument/)

--- a/web/app.js
+++ b/web/app.js
@@ -641,8 +641,13 @@ async function loadNotes(signal, onPhase = () => {}) {
 function documentKnowledgeBases(bases = state.knowledgeBases) {
   const active = bases.filter(base => base.status === 'active')
   if (!state.mountContext.sessionId) return active
+  // Session context: mounted bases stay on top; unmounted ones remain
+  // browsable (marked 未挂载 in the tree) instead of being hidden entirely.
   const mountedIds = new Set(state.resolvedMounts.map(mount => mount.knowledgeBaseId))
-  return active.filter(base => mountedIds.has(base.id))
+  return [
+    ...active.filter(base => mountedIds.has(base.id)),
+    ...active.filter(base => !mountedIds.has(base.id)),
+  ]
 }
 
 function sessionDocumentWorkspace() {
@@ -882,6 +887,89 @@ async function startBlankDocument(workspace, baseId) {
   const emptyDraft = editor?.isNew && !editor.title.trim() && !editor.body.trim()
   if (editor?.dirty && !emptyDraft && !await saveDocumentEditor(workspace)) return
   createBlankDocument(workspace, baseId)
+}
+
+async function startMarkdownImport(workspace, baseId) {
+  let utils
+  try { utils = await loadImportUtils() } catch (error) {
+    return showToast('导入组件加载失败，请刷新页面重试。', 'error')
+  }
+  const picker = element('input', { type: 'file', accept: utils.IMPORT_ACCEPT, style: 'display: none' })
+  document.body.append(picker)
+  picker.addEventListener('change', () => {
+    const file = picker.files && picker.files[0]
+    picker.remove()
+    if (!file) return
+    if (!/\.(markdown|md)$/i.test(file.name)) return showToast('仅支持 .md / .markdown 文件。', 'error')
+    if (file.size > 32 * 1024 * 1024) return showToast('文件超过 32MB，无法导入。', 'error')
+    void importMarkdownFile(workspace, baseId, file, utils)
+  })
+  picker.click()
+}
+
+async function importMarkdownFile(workspace, baseId, file, utils) {
+  let text
+  try { text = await file.text() } catch (error) { return showToast('读取文件失败。', 'error') }
+  const chunks = utils.splitMarkdownByH2(text, utils.IMPORT_MAX_BODY_CHARS)
+  if (chunks.length === 0) return showToast('文件内容为空。', 'error')
+  const activeBases = state.knowledgeBases.filter(item => item.status === 'active')
+  const preferred = activeBases.find(item => item.id === baseId)
+    || activeBases.find(item => item.id === workspace.view.knowledgeBaseId)
+    || activeBases[0]
+  if (!preferred) return showToast('请先创建或选择一个可用知识库。', 'error')
+  const defaultTitle = utils.titleFromMarkdown(file.name, text)
+  const multi = chunks.length > 1
+  const titleField = formField('文档标题', 'text', multi ? `${defaultTitle}（1/${chunks.length}）` : defaultTitle, { maxlength: 200 })
+  const baseSelect = selectField('目标知识库', activeBases.map(item => ({ value: item.id, label: item.name })), preferred.id)
+  const typeSelect = selectField('类型', TYPES.map(type => ({ value: type, label: TYPE_LABELS[type] })), 'fact')
+  const tagsField = formField('标签（逗号分隔）', 'text', '', { placeholder: '可选' })
+  const scopeOptions = [{ value: 'global', label: '全局' }]
+  if (mountContext.projectId) scopeOptions.push({ value: 'project', label: `当前项目（${mountContext.projectId}）` })
+  const scopeSelect = selectField('范围', scopeOptions, mountContext.projectId ? 'project' : 'global')
+  openSheet({
+    title: multi ? `导入 Markdown（将拆分为 ${chunks.length} 篇）` : '导入 Markdown 文档',
+    description: `文件：${file.name} · 正文超过 5 万字符时按 H2 标题拆分为多篇`,
+    body: element('form', { class: 'form-grid' },
+      baseSelect.wrapper, titleField.wrapper, typeSelect.wrapper, tagsField.wrapper, scopeSelect.wrapper),
+    primaryLabel: '导入',
+    onPrimary: async () => {
+      const title = titleField.input.value.trim()
+      if (!title) { showToast('请填写文档标题。', 'error'); return false }
+      const knowledgeBaseId = baseSelect.input.value
+      const scope = scopeSelect.input.value === 'project' && mountContext.projectId
+        ? { kind: 'project', id: mountContext.projectId }
+        : { kind: 'global' }
+      const tags = parseTags(tagsField.input.value)
+      const baseTitle = title.replace(/（\d+\/\d+）\s*$/u, '').trim() || title
+      const created = []
+      try {
+        for (const [index, body] of chunks.entries()) {
+          const entryTitle = (index === 0 ? title : `${baseTitle}（${index + 1}/${chunks.length}）`).slice(0, 200)
+          created.push(await api('entries', { method: 'POST', body: { draft: {
+            knowledgeBaseId, title: entryTitle, body, type: typeSelect.input.value, tags, scope, confidence: 0.9,
+          } } }))
+        }
+      } catch (error) {
+        showToast(`已导入 ${created.length}/${chunks.length} 篇后失败：${friendlyError(error)}`, 'error')
+        return false
+      }
+      showToast(multi ? `已导入 ${chunks.length} 篇文档。` : '已导入文档。')
+      workspace.view.knowledgeBaseId = knowledgeBaseId
+      workspace.view.expandedBases.add(knowledgeBaseId)
+      await loadDocumentPage(workspace, knowledgeBaseId, { reset: true }).catch(() => {})
+      renderShell()
+      if (created.length === 1 && created[0]?.id) await selectDocument(workspace, created[0].id).catch(() => {})
+      return true
+    },
+  })
+  titleField.input.focus()
+}
+
+function loadImportUtils() {
+  if (!loadImportUtils.promise) {
+    loadImportUtils.promise = import(`./import-utils.js${ASSET_VERSION ? `?v=${encodeURIComponent(ASSET_VERSION)}` : ''}`)
+  }
+  return loadImportUtils.promise
 }
 
 async function selectDocument(workspace, id) {
@@ -1381,6 +1469,7 @@ function renderKnowledgeBaseDetail() {
       element('div', { class: 'library-detail-actions' },
         archived ? actionButton('恢复知识库', () => confirmRestoreKnowledgeBase(base), 'small') : actionButton('编辑知识库', () => openKnowledgeBaseEditor(base), 'small'),
         !archived ? actionButton('+ 新建文档', () => { void startBlankDocument(workspace, base.id) }, 'primary small') : null,
+        !archived ? actionButton('导入文件', () => { void startMarkdownImport(workspace, base.id) }, 'small') : null,
       ),
     ),
     archived ? element('div', { class: 'library-detail-notice', role: 'status' }, '这个知识库已经归档。文档仍可阅读，但恢复知识库后才能新建或修改。') : null,
@@ -1651,6 +1740,9 @@ function renderDocumentWorkspace(workspace, options = {}) {
       element('span', { class: 'tree-disclosure', 'aria-hidden': 'true' }),
       element('span', { class: 'tree-folder-icon', 'aria-hidden': 'true' }),
       element('span', { class: 'tree-base-name' }, base.name),
+      workspace.kind === 'session' && state.mountContext.sessionId
+        && !state.resolvedMounts.some(mount => mount.knowledgeBaseId === base.id)
+        ? badge('未挂载到当前会话') : null,
       element('span', { class: 'tree-count' }, query ? documents.length : page.loaded ? page.total : '—')),
       expanded ? element('div', { class: 'note-tree-documents', role: 'group', 'aria-label': `${base.name}文档` },
         !query && page.loading && documents.length === 0 ? element('div', { class: 'note-tree-status', role: 'status' }, '正在读取目录…') : null,
@@ -1686,7 +1778,7 @@ function renderDocumentWorkspace(workspace, options = {}) {
         onClick: () => { void loadDocumentSearch(workspace, false) },
       }, view.searchLoading ? '正在加载…' : `继续加载搜索结果（${view.searchResults.length} / ${view.searchTotal}）`) : null,
     ]
-    : tree.length ? tree : [element('div', { class: 'note-tree-empty' }, workspace.kind === 'session' && state.mountContext.sessionId ? '当前会话未挂载知识库' : '还没有知识库')]
+    : tree.length ? tree : [element('div', { class: 'note-tree-empty' }, '还没有知识库')]
   return element('section', {
     class: `note-workspace note-workspace--${workspace.kind}`, 'aria-labelledby': `${workspace.kind}-documents-heading`,
     'data-tree-open': String(view.treeOpen),
@@ -1695,6 +1787,7 @@ function renderDocumentWorkspace(workspace, options = {}) {
       element('header', { class: 'note-tree-header' },
         element('div', {}, element('h2', { id: `${workspace.kind}-documents-heading` }, options.heading || '知识目录'), element('span', {}, query ? `${view.searchTotal} 条搜索结果` : `${workspaceDocuments.length} 篇已加载`)),
         !readOnly ? actionButton('+', () => { void startBlankDocument(workspace, view.knowledgeBaseId || activeBases[0]?.id) }, 'ghost note-add-button', { 'aria-label': '新建文档', title: '新建文档' }) : null,
+        !readOnly ? actionButton('导入', () => { void startMarkdownImport(workspace, view.knowledgeBaseId || activeBases[0]?.id) }, 'ghost small', { 'aria-label': '导入 Markdown 文件', title: '导入 .md 文件' }) : null,
       ),
       element('div', { class: 'note-tree-search-wrap' }, interfaceIcon('search', 'search-symbol'), search),
       element('nav', { class: 'note-tree', 'data-scroll-key': `${workspace.kind}-note-tree` }, treeContent),

--- a/web/import-utils.js
+++ b/web/import-utils.js
@@ -1,0 +1,109 @@
+/**
+ * Pure helpers for Markdown file import. Loaded by web/app.js as an ES module
+ * and imported directly by node tests, so it must stay dependency-free and
+ * DOM-free.
+ */
+
+export const IMPORT_MAX_BODY_CHARS = 50_000
+export const IMPORT_ACCEPT = '.md,.markdown'
+
+const TITLE_MAX_CHARS = 200
+
+/**
+ * Derives a document title: the first Markdown heading if present, otherwise
+ * the file name without its .md/.markdown extension.
+ */
+export function titleFromMarkdown(fileName, text) {
+  const source = typeof text === 'string' ? text : ''
+  if (source.length > 0) {
+    for (const line of source.split(/\r?\n/)) {
+      const trimmed = line.trim()
+      if (!trimmed) continue
+      const heading = /^#{1,6}\s+(.+?)\s*#*$/u.exec(trimmed)
+      if (heading && heading[1].trim()) return heading[1].trim().slice(0, TITLE_MAX_CHARS)
+      break
+    }
+  }
+  const base = String(fileName ?? '').replace(/\.(markdown|md)$/i, '').trim()
+  return base.slice(0, TITLE_MAX_CHARS) || '导入文档'
+}
+
+/**
+ * Splits Markdown into chunks that each fit the knowledge body limit,
+ * preferring H2 section boundaries. Returns at least one chunk for non-empty
+ * input; each chunk is non-empty and at most maxChars long.
+ */
+export function splitMarkdownByH2(text, maxChars = IMPORT_MAX_BODY_CHARS) {
+  const source = String(text ?? '').trim()
+  if (!source) return []
+  if (source.length <= maxChars) return [source]
+  const lines = source.split(/\r?\n/)
+  const boundaries = []
+  let offset = 0
+  for (const line of lines) {
+    if (/^##\s+\S/u.test(line)) boundaries.push(offset)
+    offset += line.length + 1
+  }
+  const parts = []
+  if (boundaries.length === 0) {
+    parts.push(source)
+  } else {
+    if (boundaries[0] > 0) parts.push(source.slice(0, boundaries[0]).trim())
+    for (let index = 0; index < boundaries.length; index += 1) {
+      const start = boundaries[index]
+      const end = index + 1 < boundaries.length ? boundaries[index + 1] : source.length
+      const section = source.slice(start, end).trim()
+      if (section) parts.push(section)
+    }
+  }
+  const chunks = []
+  let buffer = ''
+  const flush = () => {
+    const trimmed = buffer.trim()
+    if (trimmed) chunks.push(trimmed)
+    buffer = ''
+  }
+  for (const part of parts) {
+    if (part.length > maxChars) {
+      flush()
+      chunks.push(...hardSplit(part, maxChars))
+      continue
+    }
+    if (!buffer) buffer = part
+    else if (buffer.length + part.length + 2 <= maxChars) buffer = `${buffer}\n\n${part}`
+    else {
+      flush()
+      buffer = part
+    }
+  }
+  flush()
+  return chunks
+}
+
+function hardSplit(text, maxChars) {
+  const chunks = []
+  let buffer = ''
+  const flush = () => {
+    const trimmed = buffer.trim()
+    if (trimmed) chunks.push(trimmed)
+    buffer = ''
+  }
+  for (const paragraph of text.split(/\n{2,}/)) {
+    if (paragraph.length > maxChars) {
+      flush()
+      for (let index = 0; index < paragraph.length; index += maxChars) {
+        const piece = paragraph.slice(index, index + maxChars).trim()
+        if (piece) chunks.push(piece)
+      }
+      continue
+    }
+    if (!buffer) buffer = paragraph
+    else if (buffer.length + paragraph.length + 2 <= maxChars) buffer = `${buffer}\n\n${paragraph}`
+    else {
+      flush()
+      buffer = paragraph
+    }
+  }
+  flush()
+  return chunks
+}


### PR DESCRIPTION
…n import

Write-back reliability (W1-W3):
- extractionMode config (detached default, inline legacy await), 300s timeout budget (0=disabled)
- abort reason semanticization: timeout vs turn-interrupt vs shutdown in extraction_jobs.last_error
- bounded auto-retry chain: 20s/60s backoff x2 with full budget + final 30min attempt (dynamic lease)
- failed+retryable terminal state persisted on every failure path; manual retry restarts the chain
- failure rescue: export turn snapshot to <DSH home>/knowledge/exports/ + GET writeback-export download (RFC5987, browser-auth)
- fire-and-forget POST retry with client-side 5s polling while running

Markdown import (W4):
- web/import-utils.js (ESM, zero-dep): title derivation, 50k body split at H2 boundaries
- import button (.md/.markdown only) in library detail and document tree header
- register import-utils.js in web.ts STATIC_ASSETS (hotfix 2.2.1: missing asset broke dynamic import)
- knowledge documents tree: show all active bases (mounted first, unmounted marked) instead of hiding unmounted ones

Tests: 72/72 green (T1-T9 writeback chain, export/download, config resolution, import helpers, static asset regression, node:test FIFO cleanup ordering, win32 mode-bit guards). Version 2.2.2.