### PR TITLE
fix: compat with DSH 0.1.2-alpha.4 Session.snapshotEvents() and adapterStream error handling

### DIFF
--- a/src/extraction.ts
+++ b/src/extraction.ts
@@ -256,18 +256,19 @@ function pendingDestination(
 }
 
 function snapshotTurn(session: SessionLike, turn: number, maxChars: number): TurnSnapshot | undefined {
+  const events = typeof session.snapshotEvents === 'function' ? session.snapshotEvents() : session.events
   let start = -1
-  for (let index = session.events.length - 1; index >= 0; index -= 1) {
-    const event = session.events[index]
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index]
     if (event?.type === 'turn/start' && event.data.turn === turn) { start = index; break }
   }
   if (start < 0) return undefined
-  const events = session.events.slice(start)
-  const userMessages = events
+  const turnEvents = events.slice(start)
+  const userMessages = turnEvents
     .filter(event => event.type === 'user/message')
     .map(event => event.data as unknown as MessageLike)
     .filter(message => message.source?.kind === 'user')
-  const assistantMessages = events
+  const assistantMessages = turnEvents
     .filter(event => event.type === 'assistant/message' && event.data.turn === turn)
     .map(event => (event.data as { message?: MessageLike }).message)
     .filter((message): message is MessageLike => message !== undefined)
@@ -510,14 +511,29 @@ async function callWithLowReasoningFallback(
   parentSignal: AbortSignal,
   system: string,
 ): Promise<{ text: string; finish?: { kind: string; failure?: { message?: string } } }> {
+  // DSH's adapterStream() catches prepareCall() errors and yields them as
+  // finish chunks (kind: 'error') instead of throwing, so try/catch alone
+  // never catches reasoning-effort rejections. Check the returned finish too.
+  const REASONING_ERROR = /reasoning|unsupported|unknown (?:field|option|parameter)|invalid (?:field|option|parameter)/i
   try {
-    return await callExtractionModel(
+    const result = await callExtractionModel(
       ctx, route, message, sessionId, maxTokens, timeoutMs, parentSignal,
       system, 'low',
     )
+    if (result.finish !== undefined && result.finish.kind === 'error') {
+      const failureMessage = result.finish.failure?.message ?? ''
+      if (REASONING_ERROR.test(failureMessage)) {
+        ctx.logger.warn(`dsh-knowledge: ${route.provider}/${route.model} does not accept reasoningEffort; retrying without it`)
+        return callExtractionModel(
+          ctx, route, message, sessionId, maxTokens, timeoutMs, parentSignal,
+          system,
+        )
+      }
+    }
+    return result
   } catch (error) {
     const messageText = error instanceof Error ? error.message : String(error)
-    if (!/reasoning|unsupported|unknown (?:field|option|parameter)|invalid (?:field|option|parameter)/i.test(messageText)) throw error
+    if (!REASONING_ERROR.test(messageText)) throw error
     ctx.logger.warn(`dsh-knowledge: ${route.provider}/${route.model} does not accept reasoningEffort; retrying without it`)
     return callExtractionModel(
       ctx, route, message, sessionId, maxTokens, timeoutMs, parentSignal,

--- a/src/index.ts
+++ b/src/index.ts
@@ -467,7 +467,7 @@ function snapshotAgent(agent: AgentLike): AgentLike {
     session: {
       id: agent.session.id,
       header: { ...agent.session.header },
-      events: [...agent.session.events],
+      events: [...(typeof agent.session.snapshotEvents === 'function' ? agent.session.snapshotEvents() : agent.session.events)],
     },
   }
 }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -19,6 +19,8 @@ export interface SessionLike {
   id: string
   header: { cwd?: string }
   events: readonly SessionEventLike[]
+  /** DSH ≥ 0.1.2-alpha.4 replaced the `events` getter with `snapshotEvents()`. */
+  snapshotEvents?: () => readonly SessionEventLike[]
 }
 
 export interface AgentLike {

--- a/src/tool-authorization.ts
+++ b/src/tool-authorization.ts
@@ -84,14 +84,15 @@ function clauseRequestsKnowledgeBaseManagement(
 }
 
 function currentDirectUserText(agent: AgentLike): string {
+  const events = typeof agent.session.snapshotEvents === 'function' ? agent.session.snapshotEvents() : agent.session.events
   let turnStart = -1
-  for (let index = agent.session.events.length - 1; index >= 0; index -= 1) {
-    if (agent.session.events[index]?.type === 'turn/start') {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    if (events[index]?.type === 'turn/start') {
       turnStart = index
       break
     }
   }
-  return agent.session.events.slice(turnStart + 1)
+  return events.slice(turnStart + 1)
     .filter(event => event.type === 'user/message')
     .map(event => event.data as unknown as MessageLike)
     .filter(message => message.source?.kind === 'user')


### PR DESCRIPTION
## Problem

Two bugs broke knowledge writeback on DSH 0.1.2-alpha.4:

### 1. `session.events` removed (breaks ALL writebacks)

DSH 0.1.2-alpha.4 removed the `get events()` getter from the Session class, replacing it with `snapshotEvents()`. The plugin still accessed `session.events` which returned `undefined`, causing:

```
Cannot read properties of undefined (reading 'length')
```

in `snapshotTurn()` (extraction.ts), `snapshotAgent()` (index.ts), and `currentDirectUserText()` (tool-authorization.ts).

### 2. `reasoningEffort` rejection not caught (breaks retry path)

DSH's `adapterStream()` catches `prepareCall()` errors and yields them as finish chunks (`{ kind: 'error', failure }`) instead of throwing. The `callWithLowReasoningFallback()` function only used `try/catch` to detect reasoning-effort rejections, so the fallback never triggered when the model didn't support `reasoningEffort` (e.g. `extrotec/glm-5.2`).

## Fix

### Bug 1: Backward-compatible `snapshotEvents()` access

```typescript
const events = typeof session.snapshotEvents === 'function' ? session.snapshotEvents() : session.events
```

- Added optional `snapshotEvents?: () => readonly SessionEventLike[]` to `SessionLike` interface (runtime.ts)
- Updated `snapshotTurn()` (extraction.ts), `snapshotAgent()` (index.ts), `currentDirectUserText()` (tool-authorization.ts)

### Bug 2: Check `finish.kind === 'error'` in addition to try/catch

```typescript
const result = await callExtractionModel(..., 'low')
if (result.finish !== undefined && result.finish.kind === 'error') {
  if (REASONING_ERROR.test(result.finish.failure?.message ?? '')) {
    // retry without reasoningEffort
  }
}
```

- Kept the original `try/catch` as fallback for edge cases where errors do throw

## Testing

- TypeScript compiles cleanly (`tsc --noEmit` passes)
- Pre-existing test failures are unrelated (test environment path issue)
- Manually verified on DSH 0.1.2-alpha.4 with `extrotec/glm-5.2` model